### PR TITLE
Check for Skript Plugin, Add null checks, refractor code

### DIFF
--- a/src/main/java/me/djdisaster/testAddon/TestAddon.java
+++ b/src/main/java/me/djdisaster/testAddon/TestAddon.java
@@ -2,6 +2,7 @@ package me.djdisaster.testAddon;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptAddon;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.IOException;
@@ -13,6 +14,23 @@ public final class TestAddon extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        Plugin skriptPlugin = getServer().getPluginManager().getPlugin("Skript");
+        if (skriptPlugin == null) {
+            getLogger().severe("Skript not found! Disabling plugin...");
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+        if (!skriptPlugin.isEnabled()) {
+            getLogger().severe("Skript is not enabled! Disabling plugin...");
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+        if (!Skript.isAcceptRegistrations()) {
+            getLogger().severe("Skript is not accepting registrations! Cannot load addon anymore. Disabling plugin...");
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+
         instance = this;
         addon = Skript.registerAddon(this);
         try {

--- a/src/main/java/me/djdisaster/testAddon/elements/java/EffRunJavaCode.java
+++ b/src/main/java/me/djdisaster/testAddon/elements/java/EffRunJavaCode.java
@@ -29,15 +29,17 @@ public class EffRunJavaCode extends Effect {
 
     @Override
     public String toString(@Nullable Event event, boolean debug) {
-        return "";//""Send bungee message to " + players.toString(event, debug) + " with text " + text.toString(event, debug);
+        return "run method " + methodName.toString(event, debug) + " in " + compiledJavaClass.toString(event, debug);
     }
 
     @Override
     protected void execute(Event event) {
-        if (compiledJavaClass.getSingle(event) instanceof CompiledJavaClass) {
-            ((CompiledJavaClass) compiledJavaClass.getSingle(event)).runMethod(methodName.getSingle(event));
-        } else if (compiledJavaClass.getSingle(event) instanceof CompiledJavaClassInstance) {
-            ((CompiledJavaClassInstance) compiledJavaClass.getSingle(event)).runMethod(methodName.getSingle(event));
+        Object compiledJavaClass = this.compiledJavaClass.getSingle(event);
+        String methodName = this.methodName.getSingle(event);
+        if (compiledJavaClass instanceof CompiledJavaClass) {
+            ((CompiledJavaClass) compiledJavaClass).runMethod(methodName);
+        } else if (compiledJavaClass instanceof CompiledJavaClassInstance) {
+            ((CompiledJavaClassInstance) compiledJavaClass).runMethod(methodName);
         } else {
             Bukkit.getLogger().warning("You have tried to run a method on a non-class/instance");
         }

--- a/src/main/java/me/djdisaster/testAddon/elements/java/ExprCompileJavaCode.java
+++ b/src/main/java/me/djdisaster/testAddon/elements/java/ExprCompileJavaCode.java
@@ -32,7 +32,6 @@ public class ExprCompileJavaCode extends SimpleExpression<CompiledJavaClass> {
         return true;
     }
 
-
     @Override
     public boolean isSingle() {
         return true;
@@ -45,10 +44,8 @@ public class ExprCompileJavaCode extends SimpleExpression<CompiledJavaClass> {
 
     @Override
     protected @Nullable CompiledJavaClass[] get(Event event) {
-
-
         // public class Test { public static void run() { System.out.println("Hello, world!"); } }
-        CompiledJavaClass compiledJavaClass = null;
+        CompiledJavaClass compiledJavaClass;
         try {
             compiledJavaClass = JavaCompilerManager.compile(className.getSingle(event), code.getSingle(event));
         } catch (Exception e) {
@@ -60,6 +57,6 @@ public class ExprCompileJavaCode extends SimpleExpression<CompiledJavaClass> {
 
     @Override
     public String toString(@Nullable Event event, boolean b) {
-        return "compile[d] java [code] from %string% with class name %string%";
+        return "compiled java code from " + code.toString(event, b) + " with class name " + className.toString(event, b);
     }
 }

--- a/src/main/java/me/djdisaster/testAddon/elements/java/ExprGetClassInstance.java
+++ b/src/main/java/me/djdisaster/testAddon/elements/java/ExprGetClassInstance.java
@@ -31,7 +31,6 @@ public class ExprGetClassInstance extends SimpleExpression<CompiledJavaClassInst
         return true;
     }
 
-
     @Override
     public boolean isSingle() {
         return true;
@@ -44,18 +43,18 @@ public class ExprGetClassInstance extends SimpleExpression<CompiledJavaClassInst
 
     @Override
     protected @Nullable CompiledJavaClassInstance[] get(Event event) {
-
-        if (!(compiledJavaClass.getSingle(event) instanceof CompiledJavaClass)) {
+        Object compiledJavaClass = this.compiledJavaClass.getSingle(event);
+        if (!(compiledJavaClass instanceof CompiledJavaClass)) {
             Bukkit.getLogger().warning("You have tried to create an instance of a non-class Object");
             return null;
         }
-        CompiledJavaClassInstance instance = ((CompiledJavaClass) compiledJavaClass.getSingle(event)).newInstance();
+        CompiledJavaClassInstance instance = ((CompiledJavaClass) compiledJavaClass).newInstance();
 
         return new CompiledJavaClassInstance[]{instance};
     }
 
     @Override
     public String toString(@Nullable Event event, boolean b) {
-        return "compile[d] java [code] from %string% with class name %string%";
+        return "instance of " + compiledJavaClass.toString(event, b);
     }
 }

--- a/src/main/java/me/djdisaster/testAddon/elements/java/ExprRunJavaCode.java
+++ b/src/main/java/me/djdisaster/testAddon/elements/java/ExprRunJavaCode.java
@@ -22,7 +22,6 @@ public class ExprRunJavaCode extends SimpleExpression<Object> {
         );
     }
 
-
     private Expression<String> methodName;
     private Expression<Object> compiledJavaClass;
 
@@ -33,7 +32,6 @@ public class ExprRunJavaCode extends SimpleExpression<Object> {
         compiledJavaClass = (Expression<Object>) exprs[1];
         return true;
     }
-
 
     @Override
     public boolean isSingle() {
@@ -47,14 +45,15 @@ public class ExprRunJavaCode extends SimpleExpression<Object> {
 
     @Override
     protected @Nullable Object[] get(Event event) {
-
-        if (compiledJavaClass.getSingle(event) instanceof CompiledJavaClass) {
+        Object compiledJavaClass = this.compiledJavaClass.getSingle(event);
+        String methodName = this.methodName.getSingle(event);
+        if (compiledJavaClass instanceof CompiledJavaClass) {
             return new Object[]{
-                    ((CompiledJavaClass) compiledJavaClass.getSingle(event)).runMethod(methodName.getSingle(event))
+                    ((CompiledJavaClass) compiledJavaClass).runMethod(methodName)
             };
-        } else if (compiledJavaClass.getSingle(event) instanceof CompiledJavaClassInstance) {
+        } else if (compiledJavaClass instanceof CompiledJavaClassInstance) {
             return new Object[]{
-                    ((CompiledJavaClassInstance) compiledJavaClass.getSingle(event)).runMethod(methodName.getSingle(event))
+                    ((CompiledJavaClassInstance) compiledJavaClass).runMethod(methodName)
             };
         } else {
             Bukkit.getLogger().warning("You have tried to run a method on a non-class/instance");
@@ -64,7 +63,6 @@ public class ExprRunJavaCode extends SimpleExpression<Object> {
 
     @Override
     public String toString(@Nullable Event event, boolean b) {
-        return "compile[d] java [code] from %string% with class name %string%";
+        return "run method " + methodName.toString(event, b) + " in " + compiledJavaClass.toString(event, b);
     }
-
 }

--- a/src/main/java/me/djdisaster/testAddon/elements/maps/EffSetAllPixels.java
+++ b/src/main/java/me/djdisaster/testAddon/elements/maps/EffSetAllPixels.java
@@ -4,20 +4,10 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
-import ch.njol.skript.lang.function.Functions;
 import ch.njol.util.Kleenean;
-import me.djdisaster.testAddon.utils.AsyncManager;
-import me.djdisaster.testAddon.utils.CompiledJavaClass;
-import me.djdisaster.testAddon.utils.CompiledJavaClassInstance;
 import me.djdisaster.testAddon.utils.CustomMap;
-import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.checkerframework.checker.nullness.qual.Nullable;
-
-import java.awt.*;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 public class EffSetAllPixels extends Effect {
     static {
@@ -28,7 +18,6 @@ public class EffSetAllPixels extends Effect {
     private Expression<Number> r;
     private Expression<Number> g;
     private Expression<Number> b;
-    private Kleenean runAsync;
 
     @SuppressWarnings("unchecked")
     @Override
@@ -37,24 +26,25 @@ public class EffSetAllPixels extends Effect {
         this.r = (Expression<Number>) expressions[1];
         this.g = (Expression<Number>) expressions[2];
         this.b = (Expression<Number>) expressions[3];
-
         return true;
     }
 
     @Override
     public String toString(@Nullable Event event, boolean debug) {
-        return "";//""Send bungee message to " + players.toString(event, debug) + " with text " + text.toString(event, debug);
+        return "set all pixels of " + map.toString(event, debug) + " to " + r.toString(event, debug) + "," + g.toString(event, debug) + "," + b.toString(event, debug);
     }
 
     @Override
     protected void execute(Event event) {
-        map.getSingle(event).setAllPixels(
-                r.getSingle(event).intValue(),
-                g.getSingle(event).intValue(),
-                b.getSingle(event).intValue()
+        Number r = this.r.getSingle(event);
+        Number g = this.g.getSingle(event);
+        Number b = this.b.getSingle(event);
+        CustomMap map = this.map.getSingle(event);
+        if (r == null || g == null || b == null || map == null) return;
+        map.setAllPixels(
+                r.intValue(),
+                g.intValue(),
+                b.intValue()
         );
-
     }
-
-
 }

--- a/src/main/java/me/djdisaster/testAddon/elements/maps/EffSetPixel.java
+++ b/src/main/java/me/djdisaster/testAddon/elements/maps/EffSetPixel.java
@@ -4,20 +4,10 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
-import ch.njol.skript.lang.function.Functions;
 import ch.njol.util.Kleenean;
-import me.djdisaster.testAddon.utils.AsyncManager;
-import me.djdisaster.testAddon.utils.CompiledJavaClass;
-import me.djdisaster.testAddon.utils.CompiledJavaClassInstance;
 import me.djdisaster.testAddon.utils.CustomMap;
-import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.checkerframework.checker.nullness.qual.Nullable;
-
-import java.awt.*;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 public class EffSetPixel extends Effect {
     static {
@@ -30,7 +20,6 @@ public class EffSetPixel extends Effect {
     private Expression<Number> r;
     private Expression<Number> g;
     private Expression<Number> b;
-    private Kleenean runAsync;
 
     @SuppressWarnings("unchecked")
     @Override
@@ -47,18 +36,25 @@ public class EffSetPixel extends Effect {
 
     @Override
     public String toString(@Nullable Event event, boolean debug) {
-        return "";//""Send bungee message to " + players.toString(event, debug) + " with text " + text.toString(event, debug);
+        return "set pixel color " + r.toString(event, debug) + "," + g.toString(event, debug) + "," + b.toString(event, debug) + " at " + x.toString(event, debug) + "," + y.toString(event, debug) + " of " + map.toString(event, debug);
     }
 
     @Override
     protected void execute(Event event) {
-        map.getSingle(event).setPixel(
-                x.getSingle(event).intValue(),
-                y.getSingle(event).intValue(),
+        Number x = this.x.getSingle(event);
+        Number y = this.y.getSingle(event);
+        Number r = this.r.getSingle(event);
+        Number g = this.g.getSingle(event);
+        Number b = this.b.getSingle(event);
+        CustomMap map = this.map.getSingle(event);
+        if (x == null || y == null || r == null || g == null || b == null || map == null) return;
 
-                r.getSingle(event).intValue(),
-                g.getSingle(event).intValue(),
-                b.getSingle(event).intValue()
+        map.setPixel(
+                x.intValue(),
+                y.intValue(),
+                r.intValue(),
+                g.intValue(),
+                b.intValue()
         );
 
     }

--- a/src/main/java/me/djdisaster/testAddon/elements/maps/ExprGetMapItem.java
+++ b/src/main/java/me/djdisaster/testAddon/elements/maps/ExprGetMapItem.java
@@ -6,18 +6,12 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
-import me.djdisaster.testAddon.utils.CompiledJavaClass;
-import me.djdisaster.testAddon.utils.CompiledJavaClassInstance;
 import me.djdisaster.testAddon.utils.CustomMap;
-import me.djdisaster.testAddon.utils.MapData;
-import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
-import java.io.*;
-import java.nio.file.Files;
 
 public class ExprGetMapItem extends SimpleExpression<ItemStack> {
     static {
@@ -27,7 +21,6 @@ public class ExprGetMapItem extends SimpleExpression<ItemStack> {
         );
     }
 
-
     private Expression<CustomMap> map;
 
     @SuppressWarnings({"NullableProblems", "unchecked"})
@@ -36,7 +29,6 @@ public class ExprGetMapItem extends SimpleExpression<ItemStack> {
         map = (Expression<CustomMap>) exprs[0];
         return true;
     }
-
 
     @Override
     public boolean isSingle() {
@@ -50,12 +42,13 @@ public class ExprGetMapItem extends SimpleExpression<ItemStack> {
 
     @Override
     protected @Nullable ItemStack[] get(Event event) {
-        return new ItemStack[]{map.getSingle(event).getItem()};
+        CustomMap map = this.map.getSingle(event);
+        if (map == null) return null;
+        return new ItemStack[]{map.getItem()};
     }
 
     @Override
     public String toString(@Nullable Event event, boolean b) {
-        return "map from object";
+        return "map from " + map.toString(event, b);
     }
-
 }

--- a/src/main/java/me/djdisaster/testAddon/elements/maps/ExprNewMap.java
+++ b/src/main/java/me/djdisaster/testAddon/elements/maps/ExprNewMap.java
@@ -6,16 +6,11 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
-import me.djdisaster.testAddon.utils.CompiledJavaClass;
-import me.djdisaster.testAddon.utils.CompiledJavaClassInstance;
 import me.djdisaster.testAddon.utils.CustomMap;
-import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
-import java.io.*;
-import java.nio.file.Files;
 
 public class ExprNewMap extends SimpleExpression<CustomMap> {
     static {
@@ -25,16 +20,11 @@ public class ExprNewMap extends SimpleExpression<CustomMap> {
         );
     }
 
-
-    //private Expression<Integer> mapID;
-
     @SuppressWarnings({"NullableProblems", "unchecked"})
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
-        //mapID = (Expression<Integer>) exprs[0];
         return true;
     }
-
 
     @Override
     public boolean isSingle() {
@@ -53,7 +43,6 @@ public class ExprNewMap extends SimpleExpression<CustomMap> {
 
     @Override
     public String toString(@Nullable Event event, boolean b) {
-        return "custom map with id %string%";
+        return "new custom map";
     }
-
 }

--- a/src/main/java/me/djdisaster/testAddon/elements/random/ExprImageFrom.java
+++ b/src/main/java/me/djdisaster/testAddon/elements/random/ExprImageFrom.java
@@ -6,16 +6,11 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
-import me.djdisaster.testAddon.utils.CompiledJavaClass;
-import me.djdisaster.testAddon.utils.CompiledJavaClassInstance;
 import me.djdisaster.testAddon.utils.ReadImage;
-import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
-import java.io.*;
-import java.nio.file.Files;
 
 public class ExprImageFrom extends SimpleExpression<ReadImage> {
     static {
@@ -25,7 +20,6 @@ public class ExprImageFrom extends SimpleExpression<ReadImage> {
         );
     }
 
-
     private Expression<String> filePath;
     private boolean isURL;
 
@@ -33,14 +27,9 @@ public class ExprImageFrom extends SimpleExpression<ReadImage> {
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
         filePath = (Expression<String>) exprs[0];
-        if (parseResult.mark == 1) {
-            isURL = false;
-        } else {
-            isURL = true;
-        }
+        isURL = parseResult.mark != 1;
         return true;
     }
-
 
     @Override
     public boolean isSingle() {
@@ -59,7 +48,6 @@ public class ExprImageFrom extends SimpleExpression<ReadImage> {
 
     @Override
     public String toString(@Nullable Event event, boolean b) {
-        return "image from file";
+        return "image from " + filePath.toString(event, b);
     }
-
 }

--- a/src/main/java/me/djdisaster/testAddon/elements/random/ExprLinesOfFile.java
+++ b/src/main/java/me/djdisaster/testAddon/elements/random/ExprLinesOfFile.java
@@ -6,8 +6,6 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
-import me.djdisaster.testAddon.utils.CompiledJavaClass;
-import me.djdisaster.testAddon.utils.CompiledJavaClassInstance;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
@@ -24,7 +22,6 @@ public class ExprLinesOfFile extends SimpleExpression<String> {
         );
     }
 
-
     private Expression<String> fileName;
 
     @SuppressWarnings({"NullableProblems", "unchecked"})
@@ -33,7 +30,6 @@ public class ExprLinesOfFile extends SimpleExpression<String> {
         fileName = (Expression<String>) exprs[0];
         return true;
     }
-
 
     @Override
     public boolean isSingle() {
@@ -47,7 +43,9 @@ public class ExprLinesOfFile extends SimpleExpression<String> {
 
     @Override
     protected @Nullable String[] get(Event event) {
-        File file = new File(fileName.getSingle(event));
+        String fileName = this.fileName.getSingle(event);
+        if (fileName == null) return null;
+        File file = new File(fileName);
         if (!file.exists()) {
             Bukkit.getLogger().warning("Tried to read from file: " + file.getPath() + " but it doesn't exist!");
             return null;
@@ -61,7 +59,6 @@ public class ExprLinesOfFile extends SimpleExpression<String> {
 
     @Override
     public String toString(@Nullable Event event, boolean b) {
-        return "compile[d] java [code] from %string% with class name %string%";
+        return "lines of file " + fileName.toString(event, b);
     }
-
 }

--- a/src/main/java/me/djdisaster/testAddon/elements/random/ExprPixelOfImage.java
+++ b/src/main/java/me/djdisaster/testAddon/elements/random/ExprPixelOfImage.java
@@ -6,18 +6,12 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
-import me.djdisaster.testAddon.utils.CompiledJavaClass;
-import me.djdisaster.testAddon.utils.CompiledJavaClassInstance;
 import me.djdisaster.testAddon.utils.ReadImage;
-import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
-import java.awt.*;
-import java.io.*;
-import java.nio.file.Files;
 
 public class ExprPixelOfImage extends SimpleExpression<Color> {
     static {
@@ -53,14 +47,17 @@ public class ExprPixelOfImage extends SimpleExpression<Color> {
 
     @Override
     protected @Nullable Color[] get(Event event) {
+        Number x = this.x.getSingle(event);
+        Number y = this.y.getSingle(event);
+        ReadImage image = this.image.getSingle(event);
+        if (x == null || y == null | image == null) return null;
         return new Color[]{
-                image.getSingle(event).getPixelAt(x.getSingle(event).intValue(),y.getSingle(event).intValue())
+                image.getPixelAt(x.intValue(), y.intValue())
         };
     }
 
     @Override
     public String toString(@Nullable Event event, boolean b) {
-        return "compile[d] java [code] from %string% with class name %string%";
+        return "pixel " + x.toString(event, b) + ", " + y.toString(event, b) + " of " + image.toString(event, b);
     }
-
 }

--- a/src/main/java/me/djdisaster/testAddon/elements/random/ExprRGBOfColour.java
+++ b/src/main/java/me/djdisaster/testAddon/elements/random/ExprRGBOfColour.java
@@ -6,18 +6,11 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
-import me.djdisaster.testAddon.utils.CompiledJavaClass;
-import me.djdisaster.testAddon.utils.CompiledJavaClassInstance;
-import me.djdisaster.testAddon.utils.ReadImage;
-import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
-import java.awt.*;
-import java.io.*;
-import java.nio.file.Files;
 
 public class ExprRGBOfColour extends SimpleExpression<Integer> {
     static {
@@ -38,7 +31,6 @@ public class ExprRGBOfColour extends SimpleExpression<Integer> {
         return true;
     }
 
-
     @Override
     public boolean isSingle() {
         return true;
@@ -51,16 +43,15 @@ public class ExprRGBOfColour extends SimpleExpression<Integer> {
 
     @Override
     protected @Nullable Integer[] get(Event event) {
-        int value;
-        if (colourToCheck == 1) {
-            value = colour.getSingle(event).getRed();
-        } else if (colourToCheck == 2) {
-            value = colour.getSingle(event).getBlue();
-        } else if (colourToCheck == 3) {
-            value = colour.getSingle(event).getGreen();
-        } else {
-            return null;
-        }
+        Color colour = this.colour.getSingle(event);
+        if (colour == null) return null;
+
+        int value = switch (colourToCheck) {
+            case 1 -> colour.getRed();
+            case 2 -> colour.getBlue();
+            case 3 -> colour.getGreen();
+            default -> 0;
+        };
 
         return new Integer[]{value};
 
@@ -68,7 +59,11 @@ public class ExprRGBOfColour extends SimpleExpression<Integer> {
 
     @Override
     public String toString(@Nullable Event event, boolean b) {
-        return "compile[d] java [code] from %string% with class name %string%";
+        return switch (colourToCheck) {
+            case 1 -> "red of " + colour.toString(event, b);
+            case 2 -> "blue of " + colour.toString(event, b);
+            case 3 -> "green of " + colour.toString(event, b);
+            default -> "";
+        };
     }
-
 }

--- a/src/main/java/me/djdisaster/testAddon/elements/random/ExprVariableAsync.java
+++ b/src/main/java/me/djdisaster/testAddon/elements/random/ExprVariableAsync.java
@@ -7,15 +7,10 @@ import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import me.djdisaster.testAddon.utils.AsyncManager;
-import me.djdisaster.testAddon.utils.CompiledJavaClass;
-import me.djdisaster.testAddon.utils.CompiledJavaClassInstance;
-import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
-import java.io.*;
-import java.nio.file.Files;
 
 public class ExprVariableAsync extends SimpleExpression<Object> {
     static {
@@ -25,7 +20,6 @@ public class ExprVariableAsync extends SimpleExpression<Object> {
         );
     }
 
-
     private Expression<String> variableName;
 
     @SuppressWarnings({"NullableProblems", "unchecked"})
@@ -34,7 +28,6 @@ public class ExprVariableAsync extends SimpleExpression<Object> {
         variableName = (Expression<String>) exprs[0];
         return true;
     }
-
 
     @Override
     public boolean isSingle() {
@@ -53,7 +46,6 @@ public class ExprVariableAsync extends SimpleExpression<Object> {
 
     @Override
     public String toString(@Nullable Event event, boolean b) {
-        return "compile[d] java [code] from %string% with class name %string%";
+        return "variable " + variableName.toString(event, b) + " async";
     }
-
 }

--- a/src/main/java/me/djdisaster/testAddon/utils/CustomMapRenderer.java
+++ b/src/main/java/me/djdisaster/testAddon/utils/CustomMapRenderer.java
@@ -6,8 +6,6 @@ import org.bukkit.map.MapRenderer;
 import org.bukkit.map.MapView;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
-
 public class CustomMapRenderer extends MapRenderer {
 
 

--- a/src/main/java/me/djdisaster/testAddon/utils/CustomMapRendererClientSide.java
+++ b/src/main/java/me/djdisaster/testAddon/utils/CustomMapRendererClientSide.java
@@ -6,7 +6,6 @@ import org.bukkit.map.MapRenderer;
 import org.bukkit.map.MapView;
 import org.jetbrains.annotations.NotNull;
 
-import java.awt.*;
 import java.util.HashMap;
 
 public class CustomMapRendererClientSide extends MapRenderer {


### PR DESCRIPTION
This PR adds a check if the skript plugin is installed on the server, is enabled, and is accepting registrations before initiating the addon.

It also adds null checks to all the elements, refractor some conditions, and removes any unused imports.