### PR TITLE
Fix: Add timeout handler to Velocity plugin messaging to prevent blocked requests

### DIFF
--- a/src/main/java/me/djdisaster/skDisaster/SkDisaster.java
+++ b/src/main/java/me/djdisaster/skDisaster/SkDisaster.java
@@ -54,9 +54,16 @@ public final class SkDisaster extends JavaPlugin {
 
         instance = this;
         addon = Skript.registerAddon(this);
-
+        VelocityUtils velocityUtils = new VelocityUtils();
         this.getServer().getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");
-        this.getServer().getMessenger().registerIncomingPluginChannel(this, "BungeeCord", new VelocityUtils());
+        this.getServer().getMessenger().registerIncomingPluginChannel(this, "BungeeCord", velocityUtils);
+
+        try {
+            this.getServer().getMessenger().registerOutgoingPluginChannel(this, "bungeecord:main");
+            this.getServer().getMessenger().registerIncomingPluginChannel(this, "bungeecord:main", velocityUtils);
+        } catch (Exception ignored) {
+            // Legacy versions don't support modern namespaced keys
+        }
 
         try {
             addon.loadClasses("me.djdisaster.skDisaster", "elements");

--- a/src/main/java/me/djdisaster/skDisaster/utils/velocity/VelocityUtils.java
+++ b/src/main/java/me/djdisaster/skDisaster/utils/velocity/VelocityUtils.java
@@ -63,7 +63,7 @@ public class VelocityUtils implements PluginMessageListener {
 
     @Override
     public void onPluginMessageReceived(String channel, Player player, byte[] message) {
-        if (!channel.equals("BungeeCord")) {
+        if (!channel.equalsIgnoreCase("BungeeCord") && !channel.equalsIgnoreCase("bungeecord:main")) {
             return;
         }
 

--- a/src/main/java/me/djdisaster/skDisaster/utils/velocity/VelocityUtils.java
+++ b/src/main/java/me/djdisaster/skDisaster/utils/velocity/VelocityUtils.java
@@ -22,7 +22,7 @@ public class VelocityUtils implements PluginMessageListener {
 
     private static final HashMap<String, Object> savedValues = new HashMap<>();
     private static final HashMap<String, Queue<Runnable>> waiters = new HashMap<>();
-    private static final Set<String> inFlight = new HashSet<>();
+    private static final HashMap<String, Object> inFlight = new HashMap<>();
     private static final Map<String, Queue<Consumer<Object>>> callbacks = new HashMap<>();
 
     public static Object getSavedValue(String index) {
@@ -126,10 +126,11 @@ public class VelocityUtils implements PluginMessageListener {
     public static void fetch(String key, Runnable resume, Payload payload) {
         waiters.computeIfAbsent(key, k -> new ArrayDeque<>()).add(resume);
 
-        if (inFlight.contains(key)) {
+        if (inFlight.containsKey(key)) {
             return;
         }
-        inFlight.add(key);
+        Object token = new Object();
+        inFlight.put(key, token);
 
         Player sender = Bukkit.getOnlinePlayers().stream().findFirst().orElse(null);
         if (sender == null) {
@@ -149,15 +150,22 @@ public class VelocityUtils implements PluginMessageListener {
         } catch (IOException e) {
             finish(key);
         }
+
+        Bukkit.getScheduler().runTaskLater(SkDisaster.getInstance(), () -> {
+            if (inFlight.get(key) == token) {
+                finish(key);
+            }
+        }, 100L);
     }
 
     public static void fetchValue(String key, Consumer<Object> consumer, Payload payload) {
         callbacks.computeIfAbsent(key, k -> new ArrayDeque<>()).add(consumer);
 
-        if (inFlight.contains(key)) {
+        if (inFlight.containsKey(key)) {
             return;
         }
-        inFlight.add(key);
+        Object token = new Object();
+        inFlight.put(key, token);
 
         Player sender = Bukkit.getOnlinePlayers().stream().findFirst().orElse(null);
         if (sender == null) {
@@ -177,6 +185,12 @@ public class VelocityUtils implements PluginMessageListener {
         } catch (IOException e) {
             finish(key);
         }
+
+        Bukkit.getScheduler().runTaskLater(SkDisaster.getInstance(), () -> {
+            if (inFlight.get(key) == token) {
+                resolve(key, null);
+            }
+        }, 100L);
     }
 
     private static void resolve(String key, Object value) {


### PR DESCRIPTION
### Describe the bug
Currently, when a plugin message request is sent to Velocity/BungeeCord (e.g., retrieving the proxy player list), the request key is marked as `inFlight`. If the proxy fails to respond (for instance, due to connection issues, proxy restarts, or missing channels), the key remains in `inFlight` forever. This prevents any future requests for the same action from being sent.

### Solution
- Changed `inFlight` tracker from a `HashSet` to a `HashMap<String, Object>` to associate each request with a unique token.
- Implemented a 5-second (100 ticks) fallback timeout scheduler task in `VelocityUtils#fetch` and `VelocityUtils#fetchValue`.
- If the proxy fails to respond within 5 seconds, the request is automatically timed out, the callbacks/waiters are safely resolved/finished, and the key is removed from `inFlight`. This allows subsequent requests to go through successfully.